### PR TITLE
Config - example URL

### DIFF
--- a/client/js/config.js.example
+++ b/client/js/config.js.example
@@ -1,2 +1,3 @@
-var configTreetrackerApi = 'http://localhost:8080/api/';
+var configTreetrackerApi = 'http://localhost:8080/api/web/';
 // copy this file to config.js, and configure your api endpoint
+// NOTE: when you use docker-compose, the api url has to match with your nginx rewrite config (dev/nginx-reverse-proxy-web-map.conf)


### PR DESCRIPTION
Ran into some difficulties when running docker-compose locally when using the proposed URL in the client config for the API. Took some digging to find out the rewrite rule for nginx matches a different path then the one proposed.