### PR TITLE
Add default optimizedBounds to config example

### DIFF
--- a/server/config/config.example.js
+++ b/server/config/config.example.js
@@ -1,4 +1,5 @@
 exports.connectionString = "postgres://user:password@host/treetrackerdb";
+exports.optimizedBounds = '57.0,9.0,17.0,-16.0';
 
 exports.smtpSettings = {
     service: "gmail",


### PR DESCRIPTION
optimizedBounds is being used in server.js without any checks if it exists or not. Took a tiny bit of digging what breaks and when, and searching slack for answers. Would be great to see this in the config example, so it doesn't break by default when spinning it up locally with the proposed config.