### PR TITLE
feat: add userid query parameter

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -164,3 +164,15 @@ margin-left:400px !important;
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+
+.alert-container {
+  display: flex;
+  justify-content: center;
+  position: absolute;
+  width: 100%;
+  z-index: 999;
+}
+
+.alert {
+  margin: 20px auto;
+}

--- a/client/index.html
+++ b/client/index.html
@@ -54,6 +54,7 @@
 </head>
 
 <body>
+  <div class="alert-container"></div>
   <div id="overlay" class="overlay_container">
     <div id="tree_info_div" class="overlay_innards">
       <span id='close-button'><div class="icon-angle-left"></div></span>

--- a/client/js/map.js
+++ b/client/js/map.js
@@ -58,6 +58,10 @@ var initMarkers = function (viewportBounds, zoomLevel) {
     }
 
     req = $.get(queryUrl, function (data) {
+      if (userid && data.data.length === 0) {
+        showAlert();
+      }
+
         // clear everything
         points = [];
         markerByPointId = {};
@@ -150,6 +154,21 @@ function setPointMarkerListeners() {
             showMarkerInfo(point, marker, i);
         });
     })
+}
+
+function showAlert() {
+  const alertHtml = `
+    <div class="alert alert-info alert-dismissible" role="alert">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      Could not find any trees associated with userid ${userid}
+    </div>
+  `;
+  // Prevent duplicate alerts after map is re-rendered
+  if ($('.alert-container').find('.alert').length === 0) {
+    $(alertHtml).prependTo('.alert-container');
+  }
 }
 
 // set up and show the marker info

--- a/server/server.js
+++ b/server/server.js
@@ -30,6 +30,7 @@ app.get('/trees', function (req, res) {
   let organization = req.query['organization'];
   let flavor = req.query['flavor'];
   let treeid = req.query['treeid'];
+  let userid = req.query['userid'];
   let join = '';
   let joinCriteria = '';
   let filter = '';
@@ -47,6 +48,9 @@ app.get('/trees', function (req, res) {
     subset = true;
   } else if(treeid) {
     filter = 'AND trees.id = ' + treeid + ' '
+    subset = true;
+  } else if(userid) {
+    filter = 'AND trees.user_id = ' + userid + ' '
     subset = true;
   }
 
@@ -118,7 +122,7 @@ app.get('/trees', function (req, res) {
       FROM   (
         SELECT Unnest(St_clusterwithin(estimated_geometric_location, $1)) clustered_locations
         FROM   trees ` + join + `
-        WHERE  active = true ` + boundingBoxQuery + filter + joinCriteria + ` ) clusters`;
+        WHERE  active = true ` + (userid ? '' : boundingBoxQuery) + filter + joinCriteria + ` ) clusters`;
       query = {
         text: sql,
         values: [clusterRadius]


### PR DESCRIPTION
Add the ability to query by `userid` in the standard views.

### Summary of changes:
* Implemented passing the `userid` parameter from the map client to the API server
* Implemented parsing of the `userid` parameter on the API server
* Implemented querying the database for all trees with the specified `user_id`
* Added a Bootstrap alert to notify the user when an empty response is received

### Known issues (fixed):
* ~~`?userid=1` returns non-empty data, but renders nothing on the map~~
* ~~No feedback is given to the user when the response is empty~~

Closes #88 