### PR TITLE
Restrict planter image to circle shape

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -104,6 +104,7 @@ b {
 	border-radius: 50%;
 	overflow: hidden;
 	width: 93px;
+	height: 93px;
 	position: relative;
 }
 

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -104,6 +104,19 @@ b {
 	border-radius: 50%;
 	overflow: hidden;
 	width: 93px;
+	position: relative;
+}
+
+.planter_image_wrap img {
+	min-width: 100%;
+  min-height: 100%;
+  width: auto;
+  max-width: 150%;
+  max-height: 150%;
+  transform: translate(-50%, -50%);
+  position: absolute;
+  top: 50%;
+  left: 50%;
 }
 
 .info_data {


### PR DESCRIPTION
quick css fix which probably works for most image sizes and shapes for planter profiles. 
the added rules are: 
restrict the image to be between 100%-150% width and height, plus center it.

potential issues: it will squash / stretch images which are very tall / very long, anything smaller than _1.0:1.5_ or bigger than _1.5:1.0_ ratios. 

for more info please see: https://github.com/Greenstand/treetracker-web-map/issues/114


tested with one sample only.

**before**:
<img width="274" alt="Screen Shot 2019-09-17 at 12 16 35 PM" src="https://user-images.githubusercontent.com/6715240/65013600-e9cce180-d945-11e9-86ba-c44cd49c82c3.png">

**after**: 
<img width="281" alt="Screen Shot 2019-09-17 at 12 14 33 PM" src="https://user-images.githubusercontent.com/6715240/65013611-fa7d5780-d945-11e9-83aa-a9a2be768af5.png">

_how it works_: stretches the image to max 150% width, and centers it in this case. there's also a restriction that the image has to be min 100% tall, so if the image would be shorter, it would stretch (which is bad):
<img width="281" alt="Screen Shot 2019-09-17 at 12 14 42 PM" src="https://user-images.githubusercontent.com/6715240/65013639-154fcc00-d946-11e9-86f9-1ede38ab0f5f.png">


NOTE: this pr does not contain a fix for rotating the image to vertically align people's faces (note of note: supposed to be a bad joke, just couldn't help myself)
