### PR TITLE
Remove bounds from userid query

### DIFF
--- a/client/js/map.js
+++ b/client/js/map.js
@@ -396,7 +396,7 @@ var initialize = function () {
         initialZoom = linkZoom;
     }
 
-    if (token != null || organization != null || treeid != null || userid != null || donor != null) {
+    if (token != null || organization != null || treeid != null || userid === null || donor != null) {
         initialZoom = 10;
         minZoom = null;    // use the minimum zoom from the current map type
     }
@@ -433,7 +433,7 @@ var initialize = function () {
     });
 
     google.maps.event.addListener(map, "idle", function() {
-        var zoomLevel = map.getZoom();
+        var zoomLevel = !firstInteraction ? initialZoom : map.getZoom();
         console.log('New zoom level: ' + zoomLevel);
         currentZoom = zoomLevel;
         initMarkers(toUrlValueLonLat(getViewportBounds(1.1)), zoomLevel);
@@ -442,7 +442,7 @@ var initialize = function () {
     // Adjust map bounds after it’s fully loaded, but only before first interaction
     google.maps.event.addListener(map, 'tilesloaded', function() {
       if (!firstInteraction &&
-        (token != null || organization != null || treeid != null || userid != null || donor != null)) {
+        (token != null || organization != null || treeid != null || userid === null || donor != null)) {
         map.fitBounds(initialBounds);
       }
     });

--- a/client/js/map.js
+++ b/client/js/map.js
@@ -46,7 +46,7 @@ var initMarkers = function (viewportBounds, zoomLevel) {
     }
     var queryUrl = treetrackerApiUrl + "trees?clusterRadius=" + clusterRadius;
     queryUrl = queryUrl + "&zoom_level=" + zoomLevel;
-    if (currentZoom >= 4 && !((token != null || organization != null || treeid != null) && firstRender == true)) {
+    if (currentZoom >= 4 && !((token != null || organization != null || treeid != null || userid !== null) && firstRender == true)) {
         queryUrl = queryUrl + "&bounds=" + viewportBounds;
     }
     if (token != null) {


### PR DESCRIPTION
looks like this check was causing the problem. not sure about the entire chain of consequences, this might be just required at first render. for now, i have just added the missing check to follow the other similar ones. 

for the related open issue, please see: https://github.com/Greenstand/treetracker-web-map/issues/108