### PR TITLE
Update notify-daily-tree-count.js to take away Region count. Total global count only. 

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -6,12 +6,12 @@
 <head>
 	<!-- made by www.metatags.org -->
 	<meta name="description" content="Treetracker is the basic mechanism to connect tree growers all over the world to an international audience. Usable by tree planting organisations as well as individual planters.   " />
-	<meta name="keywords" content="trees, tree tracker, greenstand, tree token, tree planting based economy, " />
+	<meta name="keywords" content="trees, treetracker, greenstand, tree token, tree planting based economy, " />
 	<meta name="author" content="metatags generator">
 	<meta name="robots" content="index, follow">
 	<meta name="revisit-after" content="3 month">
 	<meta name="viewport" content="width=device-width,initial-scale=1.0" />
-	<title>Treetracker, a tool that brings transparency into the world of tree planting </title>
+	<title>Treetracker by Greenstand</title>
 	<!-- trees, treetracker, greenstand -->
 	<!-- Global site tag (gtag.js) - Google Analytics -->
 	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-1280531-63"></script>

--- a/server/cron/notify-daily-tree-count.js
+++ b/server/cron/notify-daily-tree-count.js
@@ -13,24 +13,19 @@ Sentry.init({ dsn: Config.sentryDSN });
 
 (async () => {
 
-  var output = "```Region       | Tree Count";
+  var output = "```Tree Count";
 
 {
   const query = {
-    text: `select r.name as region_name
-      , count(distinct t.id) as trees
-    from trees t
-    inner join tree_region tr on tr.tree_id = t.id
-    inner join region r on r.id = tr.region_id
-    where time_created > now() - INTERVAL '1 day'
-      and r.id in (6632386, 6632476) -- Kenya and Tanzania
-      and t.active = true
-    group by r.id`
+    text: `select count(distinct t.id) as trees
+from trees t
+where time_created > now() - INTERVAL ‘1 day’
+and t.active = true`
   };
   rval = await pool.query(query);
   for(let row of rval.rows){
    console.log(row);
-   const string = row.region_name.padEnd(12) + ' | ' + row.trees;
+   const string = ' Total trees tracked ' + row.trees;
    output = output + "\n" +  string;
   }
   console.log(output);
@@ -38,23 +33,6 @@ Sentry.init({ dsn: Config.sentryDSN });
   
 }
 
-{
-  const query = {
-    text: `Select 'Global Total' as region_name
-     , count(distinct t.id) as trees
-    from trees t
-    where t.active = true
-      and time_created > now() - INTERVAL '1 day'`
-  };
-  rval = await pool.query(query);
-  for(let row of rval.rows){
-   console.log(row);
-   const string = row.region_name.padEnd(12) + ' | ' + row.trees;
-   output = output + "\n" +  string;
-  }
-  console.log(output);
-
-}
 
   output = output + '```';
   if(output != null) {
@@ -66,7 +44,7 @@ Sentry.init({ dsn: Config.sentryDSN });
       body: {
         attachments: [
           {
-            "title": "Trees Planted in the last 24 hours: Tanzania, Kenya and globally ",
+            "title": "Trees Planted in the last 24 hours globally: ",
             "text": output,
           }
         ]


### PR DESCRIPTION
This should work again but leaving out the regions. We dont really need them. I did not manage to test the js script but the sql is tested. Am sure the loop for() is no longer needed but i left it in for now. 