### PR TITLE
correct initial zoom level

### DIFF
--- a/client/js/map.js
+++ b/client/js/map.js
@@ -527,8 +527,8 @@ var initialize = function() {
   console.log(wallet);
   loader = document.getElementById("map-loader");
 
-  var initialZoom = 2;
-  var minZoom = 2;
+  var initialZoom = 10;
+  var minZoom = 10;
 
   var linkZoom = parseInt(getQueryStringValue("zoom"));
   if (linkZoom) {


### PR DESCRIPTION
Correcting the zoom level to 10 also allows for the correct bounds to be used on init