### PR TITLE
Fixed: throw error when lat/lng is string type

### DIFF
--- a/client/js/mapTools.js
+++ b/client/js/mapTools.js
@@ -65,9 +65,14 @@ function getAngleLat(north, south){
  */
 function getInitialBounds (locations, width, height){
   chai.expect(locations).a("array").lengthOf.gte(1);
+  //convert
+  locations.forEach(location => {
+    location.lat = parseFloat(location.lat);
+    location.lng = parseFloat(location.lng);
+  });
   locations.every(location => {
-    chai.expect(location).property("lat").a("number");
-    chai.expect(location).property("lng").a("number");
+    chai.expect(location).property("lat").a("number").not.NaN;
+    chai.expect(location).property("lng").a("number").not.NaN;
   });
   chai.expect(width).gt(0);
   chai.expect(height).gt(0);

--- a/client/js/mapTools.test.js
+++ b/client/js/mapTools.test.js
@@ -78,10 +78,6 @@ describe("MapTools", () => {
 describe("getInitialBounds", () => {
 
   beforeAll(() => {
-  });
-
-
-  it("getInitialBounds(0,0)", () => {
     global.google = {
       maps: {
         LatLngBounds: jest.fn().mockImplementation(() => ({
@@ -101,6 +97,10 @@ describe("getInitialBounds", () => {
         })),
       },
     };
+  });
+
+
+  it("getInitialBounds(0,0)", () => {
     const result = mapTools.getInitialBounds([{lat:0, lng:0}], 500, 500);
     expect(result).toMatchObject({
       center: {
@@ -110,4 +110,29 @@ describe("getInitialBounds", () => {
       zoomLevel: expect.anything(),
     });
   });
+
+  it("getInitialBounds('0','0')", () => {
+    const result = mapTools.getInitialBounds([{lat:"0", lng:"0"}], 500, 500);
+    expect(result).toMatchObject({
+      center: {
+        lat: 0,
+        lng: 0,
+      },
+      zoomLevel: expect.anything(),
+    });
+  });
+
+  it("getInitialBounds('s','s') shoudl throw", () => {
+    expect(() => {
+      const result = mapTools.getInitialBounds([{lat:"s", lng:"s"}], 500, 500);
+      expect(result).toMatchObject({
+        center: {
+          lat: 0,
+          lng: 0,
+        },
+        zoomLevel: expect.anything(),
+      });
+    }).toThrow();
+  });
+
 });


### PR DESCRIPTION
Resolve #170 

The reason leading to this issue:

When calculating the initial bounds for the map, in some cases, like this one: ?userid=xxx, the latitude and longitude from the server is STRING type, so the code detected that it's not a number, so throw an error. 