### PR TITLE
Added: where condition to filter unapproved trees when find nearest trees.

### DIFF
--- a/server/api/nearest.js
+++ b/server/api/nearest.js
@@ -72,6 +72,8 @@ router.get("/", async function (req, res, next) {
     ST_ASGeoJson(estimated_geometric_location)
   FROM
     trees
+  WHERE
+    active = true
   ORDER BY
     estimated_geometric_location <->
     ST_SetSRID(ST_MakePoint(${lng}, ${lat}),4326)

--- a/server/api/nearest.test.js
+++ b/server/api/nearest.test.js
@@ -35,7 +35,7 @@ describe("nearest", () => {
     expect(new Pool().query).toBeDefined();
     expect(response.statusCode).toBe(200);
     expect(query).toHaveBeenCalledWith({
-      text: expect.stringMatching(/select.*trees.*/is),
+      text: expect.stringMatching(/select.*trees.*active.*=.*true.*/is),
       values: expect.anything(),
     });
     expect(response.body).toMatchObject({


### PR DESCRIPTION
Resolve #209 

The problem is: didn't filter out the unapproved trees when finding the nearest tree.