### PR TITLE
Restored customized logo function

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -11,6 +11,7 @@ import Loader from "./components/Loader";
 import Fade from "@material-ui/core/Fade";
 import MuiAlert from "@material-ui/lab/Alert";
 import Snackbar from "@material-ui/core/Snackbar";
+import getLogo from "./models/logo";
 
 
 console.log("ppppp", process.env.REACT_APP_PPP);
@@ -241,6 +242,7 @@ function App() {
   const [logoLoaded, setLogoLoaded] = React.useState(false);
   const [message, setMessage] = React.useState({open: false, message:""});
   const [arrow, setArrow] = React.useState({});
+  const [logoSrc, setLogoSrc] = React.useState(undefined);
 
   function showPanel(tree){
     console.log("show panel...");
@@ -386,7 +388,6 @@ function App() {
 
 
   React.useEffect(() => {
-    setLogoLoaded(true);
     const script = document.createElement('script');
     script.src = 'https://maps.googleapis.com/maps/api/js?key=AIzaSyDUGv1-FFd7NFUS6HWNlivbKwETzuIPdKE&libraries=geometry';
     script.id = 'googleMaps';
@@ -400,6 +401,20 @@ function App() {
         .property("current").defined();
       injectApp();
     };
+  }, []);
+
+  /*
+   * Deal with the logo, loading the logo first, for case like wallet, need to
+   * fetch possible logo url in DB
+   */
+  async function loadLogo(){
+    const src = await getLogo(window.location.href);
+    setLogoSrc(src);
+    setLogoLoaded(true);
+  }
+
+  React.useEffect(() => {
+    loadLogo();
   }, []);
 
   return (
@@ -423,7 +438,7 @@ function App() {
         </Grid>
       </Fade>
       <div className={`${classes.logo} ${logoLoaded?classes.logoLoaded:""}`}>
-        <img alt="logo" src={require("./images/logo_floating_map.svg")} />
+        <img alt="logo" src={logoSrc} />
       </div>
       <Snackbar open={message.open} autoHideDuration={10000} onClose={handleMessageClose}>
         <MuiAlert onClose={handleMessageClose} severity="warning">

--- a/client/src/models/entity.js
+++ b/client/src/models/entity.js
@@ -23,6 +23,13 @@ const entity = {
     }
     return res.data;
   },
+  getByMapName: async function(name){
+    const res = await axios.get(`${treetrackerApiUrl}entities?map_name=${name}`);
+    if(res.status !== 200){
+      throw Error("entity load fails");
+    }
+    return res.data;
+  },
 };
 
 module.exports = entity;

--- a/client/src/models/entity.js
+++ b/client/src/models/entity.js
@@ -1,0 +1,28 @@
+/*
+ * get entity, edit the DOM
+ */
+const axios = require("axios");
+const treetrackerApiUrl = process.env.REACT_APP_API || "/api/web/";
+
+let isLoadingMarkers = false;
+
+
+const entity = {
+  name: "entity",
+  getById: async function(id){
+    const res = await axios.get(`${treetrackerApiUrl}entities/${id}`);
+    if(res.status !== 200){
+      throw Error("entity load fails");
+    }
+    return res.data;
+  },
+  getByWallet: async function(name){
+    const res = await axios.get(`${treetrackerApiUrl}entities?wallet=${name}`);
+    if(res.status !== 200){
+      throw Error("entity load fails");
+    }
+    return res.data;
+  },
+};
+
+module.exports = entity;

--- a/client/src/models/entity.test.js
+++ b/client/src/models/entity.test.js
@@ -1,0 +1,59 @@
+const entity = require("./entity");
+const axios = require("axios");
+
+jest.mock("axios");
+
+describe("entity", () => {
+
+  beforeEach(async () => {
+  });
+
+  afterAll(() => {
+    jest.clearAllMock();
+  });
+
+  it("module defined", async () => {
+    console.log("entity:", entity);
+    expect(entity).toMatchObject({
+      name: "entity",
+    });
+    expect(entity.getById).toBeDefined();
+    expect(entity.getByWallet).toBeDefined();
+  });
+
+  it("getById(1)", async () => {
+    axios.get = jest.fn(() => ({
+      status: 200,
+      data: {
+        id: 1,
+        name: "Zaven",
+        logoUrl: "http://logo",
+      },
+    }));
+    const e = await entity.getById(1);
+    expect(axios.get).toHaveBeenCalledWith("/api/web/entities/1");
+    expect(e).toMatchObject({
+      id: 1,
+      name: "Zaven",
+      logoUrl: "http://logo",
+    });
+  });
+
+  it("getByWallet('Zaven')", async () => {
+    axios.get = jest.fn(() => ({
+      status: 200,
+      data: [{
+        id: 1,
+        name: "Zaven",
+        logoUrl: "http://logo",
+      }],
+    }));
+    const e = await entity.getByWallet("Zaven");
+    expect(axios.get).toHaveBeenCalledWith("/api/web/entities?wallet=Zaven");
+    expect(e).toMatchObject([{
+      id: 1,
+      name: "Zaven",
+      logoUrl: "http://logo",
+    }]);
+  });
+});

--- a/client/src/models/entity.test.js
+++ b/client/src/models/entity.test.js
@@ -31,7 +31,7 @@ describe("entity", () => {
       },
     }));
     const e = await entity.getById(1);
-    expect(axios.get).toHaveBeenCalledWith("/api/web/entities/1");
+    expect(axios.get).toHaveBeenCalledWith("/entities/1");
     expect(e).toMatchObject({
       id: 1,
       name: "Zaven",
@@ -49,10 +49,28 @@ describe("entity", () => {
       }],
     }));
     const e = await entity.getByWallet("Zaven");
-    expect(axios.get).toHaveBeenCalledWith("/api/web/entities?wallet=Zaven");
+    expect(axios.get).toHaveBeenCalledWith("/entities?wallet=Zaven");
     expect(e).toMatchObject([{
       id: 1,
       name: "Zaven",
+      logoUrl: "http://logo",
+    }]);
+  });
+
+  it("getByMapName('freetown')", async () => {
+    axios.get = jest.fn(() => ({
+      status: 200,
+      data: [{
+        id: 1,
+        name: "freetown",
+        logoUrl: "http://logo",
+      }],
+    }));
+    const e = await entity.getByMapName("freetown");
+    expect(axios.get).toHaveBeenCalledWith("/entities?map_name=freetown");
+    expect(e).toMatchObject([{
+      id: 1,
+      name: "freetown",
       logoUrl: "http://logo",
     }]);
   });

--- a/client/src/models/logo.js
+++ b/client/src/models/logo.js
@@ -1,0 +1,25 @@
+const entity = require("./entity");
+
+async function getLogo(url){
+  let src = require("../images/logo_floating_map.svg");
+  const m = url.match(/.*wallet=(.\S+)/);
+  console.log("m:", m);
+  let wallet;
+  if(m){
+    wallet = m[1];
+  }else{
+    const at = url.match(/https?:\/\.*.*@(.\S+)/);
+    if(at){
+      wallet = at[1];
+    }
+  }
+  if(wallet){
+    const entities = await entity.getByWallet(wallet);
+    if(entities && entities.length > 0 && entities[0].logo_url){
+      src = entities[0].logo_url;
+    }
+  }
+  return src;
+}
+
+module.exports = getLogo;

--- a/client/src/models/logo.js
+++ b/client/src/models/logo.js
@@ -1,4 +1,6 @@
 const entity = require("./entity");
+const {parseDomain} = require("./utils");
+const {parseMapName} = require("../utils");
 
 async function getLogo(url){
   let src = require("../images/logo_floating_map.svg");
@@ -17,6 +19,34 @@ async function getLogo(url){
     const entities = await entity.getByWallet(wallet);
     if(entities && entities.length > 0 && entities[0].logo_url){
       src = entities[0].logo_url;
+    }
+  }
+  
+  //map name
+  const domain = parseDomain(url);
+  if(domain){
+    const mapName = parseMapName(domain);
+    if(mapName){
+      const entities = await entity.getByMapName(mapName);
+      if(entities && entities.length > 0 && entities[0].logo_url){
+        src = entities[0].logo_url;
+      }
+    }
+  }
+
+  //map name case2
+  {
+    const m = url.match(/.*map_name=(.\S+)/);
+    console.log("m:", m);
+    let mapName;
+    if(m){
+      mapName = m[1];
+    }
+    if(mapName){
+      const entities = await entity.getByMapName(mapName);
+      if(entities && entities.length > 0 && entities[0].logo_url){
+        src = entities[0].logo_url;
+      }
     }
   }
   return src;

--- a/client/src/models/logo.test.js
+++ b/client/src/models/logo.test.js
@@ -1,0 +1,49 @@
+const entity = require("./entity");
+const getLogo = require("./logo.js");
+
+jest.mock("./entity");
+
+
+
+describe("Logo", () => {
+  let logoOriginal = "/img/logo_floating_map.svg";
+  let logoCustomer = "http://zaven.com/logo.svg";
+
+  beforeEach(async () => {
+  });
+
+
+  it("getLogo('http://localhost:3000') should return Greenstand logo", async () => {
+    const logo = await getLogo("http://localhost:3000");
+    //in this case, should return a object, cuz we can use a src string for local image
+    expect(typeof logo).toBe("object");
+  });
+
+  it("getLogo('http://localhost:3000/?wallet=Zaven", async () => {
+    entity.getByWallet.mockResolvedValue([{
+      logo_url: logoCustomer,
+    }]);
+    const logo = await getLogo("http://localhost:3000/?wallet=Zaven");
+    expect(entity.getByWallet).toHaveBeenCalled();
+    expect(logo).toBe(logoCustomer);
+  });
+
+  it("getLogo('http://localhost:3000/@Zaven", async () => {
+    entity.getByWallet.mockResolvedValue([{
+      logo_url: logoCustomer,
+    }]);
+    const logo = await getLogo("http://localhost:3000/@Zaven");
+    expect(entity.getByWallet).toHaveBeenCalled();
+    expect(logo).toBe( logoCustomer);
+  });
+
+  it("getLogo('https://localhost:3000/@Zaven", async () => {
+    entity.getByWallet.mockResolvedValue([{
+      logo_url: logoCustomer,
+    }]);
+    const logo = await getLogo("https://localhost:3000/@Zaven");
+    expect(entity.getByWallet).toHaveBeenCalled();
+    expect(logo).toBe( logoCustomer);
+  });
+
+});

--- a/client/src/models/logo.test.js
+++ b/client/src/models/logo.test.js
@@ -46,4 +46,22 @@ describe("Logo", () => {
     expect(logo).toBe( logoCustomer);
   });
 
+  it("getLogo('https://freetown.greenstand.org", async () => {
+    entity.getByMapName.mockResolvedValue([{
+      logo_url: logoCustomer,
+    }]);
+    const logo = await getLogo("https://freetown.greenstand.org");
+    expect(entity.getByMapName).toHaveBeenCalled();
+    expect(logo).toBe( logoCustomer);
+  });
+
+  it("getLogo('https://greenstand.org/?map_name=freetown", async () => {
+    entity.getByMapName.mockResolvedValue([{
+      logo_url: logoCustomer,
+    }]);
+    const logo = await getLogo("https://greenstand.org/?map_name=freetown");
+    expect(entity.getByMapName).toHaveBeenCalledWith("freetown");
+    expect(logo).toBe( logoCustomer);
+  });
+
 });

--- a/client/src/models/utils.js
+++ b/client/src/models/utils.js
@@ -1,0 +1,15 @@
+
+module.exports.parseDomain = function(url){
+  const matcher = url.match(/^https?\:\/\/([^\/]*)\/?.*$/);
+  if(matcher){
+    const domainWithPort = matcher[1];
+    const matcher2 = domainWithPort.match(/^(.*)\:\d+$/);
+    if(matcher2){
+      return matcher2[1];
+    }else{
+      return domainWithPort;
+    }
+  }else{
+    return undefined;
+  }
+}

--- a/client/src/models/utils.test.js
+++ b/client/src/models/utils.test.js
@@ -1,0 +1,32 @@
+const {parseDomain} = require("./utils");
+
+describe("parseDomain", () => {
+  it("https://freetown.treetracker.org", () => {
+    expect(parseDomain("https://freetown.treetracker.org")).toBe("freetown.treetracker.org");
+  });
+
+  it("http://freetown.treetracker.org", () => {
+    expect(parseDomain("http://freetown.treetracker.org")).toBe("freetown.treetracker.org");
+  });
+
+  it("https://treetracker.org/", () => {
+    expect(parseDomain("https://treetracker.org/")).toBe("treetracker.org");
+  });
+
+  it("https://treetracker.org", () => {
+    expect(parseDomain("https://treetracker.org")).toBe("treetracker.org");
+  });
+
+  it("http://localhost:3000", () => {
+    expect(parseDomain("https://localhost:3000")).toBe("localhost");
+  });
+
+  it("http://localhost", () => {
+    expect(parseDomain("https://localhost")).toBe("localhost");
+  });
+
+  it("https://treetracker.org/?wallet=xxxx", () => {
+    expect(parseDomain("https://treetracker.org/?wallet=xxxx")).toBe("treetracker.org");
+  });
+
+});

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -1,0 +1,22 @@
+function parseMapName(domain){
+  const matcher = domain.match(/^((\w+\.?)+org|localhost)$/);
+  if(matcher){
+    if(domain === "localhost"){
+      return undefined;
+    }
+    const sub = domain.match(/([^.]+)/g);
+    //discard primary domain
+    sub.pop();
+    sub.pop();
+    if(sub.length > 0 && sub[0] !== "test" && sub[0] !== "dev"){
+      return sub[0];
+    }else{
+      return undefined;
+    }
+  }else{
+    throw new Error(`the domain is wrong :${domain}`);
+  }
+}
+
+
+module.exports = {parseMapName}

--- a/client/src/utils.test.js
+++ b/client/src/utils.test.js
@@ -1,0 +1,32 @@
+const {parseMapName} = require("./utils");
+
+describe("parseMapName", () => {
+
+  it("freetown.treetracker.org should return freetown", () => {
+    expect(parseMapName("freetown.treetracker.org")).toBe("freetown");
+  });
+
+  it("treetracker.org should return undefined", () => {
+    expect(parseMapName("treetracker.org")).toBeUndefined();
+  });
+
+  it("test.treetracker.org should return undefined", () => {
+    expect(parseMapName("test.treetracker.org")).toBeUndefined();
+  });
+
+  it("dev.treetracker.org should return undefined", () => {
+    expect(parseMapName("dev.treetracker.org")).toBeUndefined();
+  });
+
+  it("localhost should return undefined", () => {
+    expect(parseMapName("localhost")).toBeUndefined();
+  });
+
+
+  it("http://dev.treetracker.org should throw error", () => {
+    expect(() => {
+      parseMapName("http://dev.treetracker.org");
+    }).toThrow();
+  });
+
+});

--- a/server/api/entity.js
+++ b/server/api/entity.js
@@ -25,6 +25,10 @@ router.get("/", async function(req, res, next){
     where = " where wallet = $1";
     values.push(req.query.wallet);
   }
+  if(req.query.map_name){
+    where = " where map_name = $1";
+    values.push(req.query.map_name);
+  }
   const query = {
     text: "select * from entity" + where, 
     values,

--- a/server/api/entity.test.js
+++ b/server/api/entity.test.js
@@ -68,4 +68,20 @@ describe("entity", () => {
       name: "zaven",
     }]);
   });
+
+  it("/entities?map_name=freetown", async () => {
+    query.mockResolvedValue({rows:[{id:1, name: "freetown"}]});
+    const response = await request(app)
+      .get("/entities?map_name=freetown")
+    expect(response.statusCode).toBe(200);
+    expect(query).toHaveBeenCalledWith({
+      text: "select * from entity where map_name = $1",
+      values: ["freetown"],
+    });
+    expect(response.body).toMatchObject([{
+      id: 1,
+      name: "freetown",
+    }]);
+  });
+
 });


### PR DESCRIPTION
The new map missed the customized logo function, which set the client's logo on the map by wallet name. 
And also extend this function to support setting logo by map name, so now we can add logo for freetown, just need to set the logo_url in the DB:
<img width="1440" alt="Screen Shot 2020-10-31 at 3 55 19 PM" src="https://user-images.githubusercontent.com/5744708/97774306-84f83900-1b91-11eb-8ffe-eebd708437d9.png">
