### PR TITLE
Fix bug/wallet subdomain

### DIFF
--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -8,7 +8,13 @@ function parseMapName(domain){
     //discard primary domain
     sub.pop();
     sub.pop();
-    if(sub.length > 0 && sub[0] !== "test" && sub[0] !== "dev"){
+    if(
+      sub.length > 0 && 
+      sub[0] !== "test" && 
+      sub[0] !== "dev" &&
+      sub[0] !== "wallet" &&
+      sub[0] !== "ready"
+    ){
       return sub[0];
     }else{
       return undefined;

--- a/client/src/utils.test.js
+++ b/client/src/utils.test.js
@@ -36,4 +36,8 @@ describe("parseMapName", () => {
     expect(parseMapName("wallet.treetracker.org")).toBeUndefined();
   });
 
+  it("ready.treetracker.org should return undefined", () => {
+    expect(parseMapName("ready.treetracker.org")).toBeUndefined();
+  });
+
 });

--- a/client/src/utils.test.js
+++ b/client/src/utils.test.js
@@ -5,6 +5,9 @@ describe("parseMapName", () => {
   it("freetown.treetracker.org should return freetown", () => {
     expect(parseMapName("freetown.treetracker.org")).toBe("freetown");
   });
+  it("treetracker.org should return undefined", () => {
+    expect(parseMapName("treetracker.org")).toBeUndefined();
+  });
 
   it("treetracker.org should return undefined", () => {
     expect(parseMapName("treetracker.org")).toBeUndefined();
@@ -27,6 +30,10 @@ describe("parseMapName", () => {
     expect(() => {
       parseMapName("http://dev.treetracker.org");
     }).toThrow();
+  });
+
+  it("wallet.treetracker.org should return undefined", () => {
+    expect(parseMapName("wallet.treetracker.org")).toBeUndefined();
   });
 
 });


### PR DESCRIPTION
Added: wallet.treetracker.org and ready.treetracker.org to the whitelist for checking the organizational map. 