### PR TITLE
Web map support both capture map and tree map.

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -410,7 +410,9 @@ function App() {
       //map.initialize();
       const url = new URL(window.location.href);
       const options = {};
-      if(url.pathname === "/capture"){
+      if(url.pathname === "/tree"){
+        options.isCapture = false;
+      }else{
         options.isCapture = true;
       }
       const map = load(options);

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -395,8 +395,12 @@ function App() {
   injectApp();
 
 
+  /*
+   * Load map
+   */
   React.useEffect(() => {
     log.debug("useEffect 1");
+    //before load map, load google map toolkit first
     const script = document.createElement('script');
     script.src = 'https://maps.googleapis.com/maps/api/js?key=AIzaSyDUGv1-FFd7NFUS6HWNlivbKwETzuIPdKE&libraries=geometry';
     script.id = 'googleMaps';
@@ -404,7 +408,12 @@ function App() {
 
     script.onload = () => {
       //map.initialize();
-      const map = load();
+      const url = new URL(window.location.href);
+      const options = {};
+      if(url.pathname === "/capture"){
+        options.isCapture = true;
+      }
+      const map = load(options);
       mapRef.current.map = map;
       expect(mapRef)
         .property("current").defined();

--- a/client/src/map.js
+++ b/client/src/map.js
@@ -18,6 +18,10 @@ const $ = {
 
 const moment = () => {log.warn("Fake moment!")};
 
+/*
+ * options:
+ *  isCapture: boolean  //the map is in capture mode
+ */
 function load(
   options
 ){
@@ -168,7 +172,7 @@ var initMarkers = function(viewportBounds, zoomLevel) {
 //    req.abort();
 //  }
   source && source.cancel("clean previous request");
-  var queryUrl = treetrackerApiUrl + "trees?clusterRadius=" + clusterRadius;
+  var queryUrl = `${treetrackerApiUrl}${options.isCapture?"captures":"trees"}?clusterRadius=${clusterRadius}`;
   queryUrl = queryUrl + "&zoom_level=" + zoomLevel;
   if (
     currentZoom >= 4 &&
@@ -958,7 +962,7 @@ class CoordMapType {
 //        req.abort();
 //      }
       source && source.cancel("clean previous request");
-      var queryUrl = treetrackerApiUrl + "trees?clusterRadius=" + clusterRadius;
+      var queryUrl = `${treetrackerApiUrl}${options.isCapture?"captures":"trees"}?clusterRadius=${clusterRadius}`;
       queryUrl = queryUrl + "&zoom_level=" + queryZoomLevel;
       queryUrl = queryUrl + treeQueryParameters;
 
@@ -990,7 +994,7 @@ class CoordMapType {
             // rerun at higher zoom level
             let queryZoomLevel12 = 12
             var queryClusterRadius12 = getQueryStringValue("clusterRadius") || getClusterRadius(queryZoomLevel12);
-            var queryUrl = treetrackerApiUrl + "trees?clusterRadius=" + queryClusterRadius12;
+            var queryUrl = `${treetrackerApiUrl}${options.isCapture?"captures":"trees"}?clusterRadius=${queryClusterRadius12}`;
             queryUrl = queryUrl + "&zoom_level=" + queryZoomLevel12;
             queryUrl = queryUrl + treeQueryParameters;
             source = CancelToken.source();

--- a/server/__tests__/integration.test.js
+++ b/server/__tests__/integration.test.js
@@ -42,4 +42,45 @@ describe("Integration tests", () => {
     }, 100000);
   });
 
+  describe.only("Capture", () => {
+    it("/captures?clusterRadius=8&zoom_level=2&map_name=freetown", async () => {
+      const res = await request(app)
+        .get("/captures?clusterRadius=8&zoom_level=2&map_name=freetown");
+      expect(res.statusCode).toBe(200);
+    }, 100000);
+
+    it("/captures?clusterRadius=0.02&zoom_level=12&bounds=0.27413497359721345,0.09675638212298909,-0.3191267451527627,-0.07998612103164923&map_name=freetown", async () => {
+      const res = await request(app)
+        .get("/captures?clusterRadius=0.02&zoom_level=12&bounds=0.27413497359721345,0.09675638212298909,-0.3191267451527627,-0.07998612103164923&map_name=freetown");
+      expect(res.statusCode).toBe(200);
+    }, 100000);
+
+    it.skip("/trees?clusterRadius=0.003&zoom_level=16&bounds=0.018839836120605472,0.005394458765216459,-0.018239021301269535,-0.0056519508298092415&map_name=freetown", async () => {
+      const res = await request(app)
+        .get("/trees?clusterRadius=0.003&zoom_level=16&bounds=0.018839836120605472,0.005394458765216459,-0.018239021301269535,-0.0056519508298092415&map_name=freetown");
+      expect(res.statusCode).toBe(200);
+    }, 90000);
+
+    it("/captures?clusterRadius=0.05&zoom_level=10&userid=12", async () => {
+      const res = await request(app)
+        .get("/captures?clusterRadius=0.05&zoom_level=10&userid=12");
+      expect(res.statusCode).toBe(200);
+    }, 100000);
+
+
+    describe("wallet map", () => {
+      it("/captures?clusterRadius=0.02&zoom_level=12&wallet=forestmatic_demo", async () => {
+        const res = await request(app)
+          .get("/captures?clusterRadius=0.02&zoom_level=12&wallet=forestmatic_demo");
+        expect(res.statusCode).toBe(200);
+      }, 100000);
+
+      it("/captures?clusterRadius=0.02&zoom_level=16&wallet=forestmatic_demo", async () => {
+        const res = await request(app)
+          .get("/captures?clusterRadius=0.02&zoom_level=16&wallet=forestmatic_demo");
+        expect(res.statusCode).toBe(200);
+      }, 100000);
+    });
+  });
+
 });

--- a/server/app.js
+++ b/server/app.js
@@ -8,6 +8,7 @@ var app = express();
 var config = require('./config/config');
 const Sentry = require('@sentry/node');
 const Map = require('./models/Map');
+const MapCapture = require('./models/MapCapture');
 
 const pool = new Pool({ connectionString: config.connectionString });
 Sentry.init({ dsn: config.sentryDSN });
@@ -37,6 +38,17 @@ app.get("/trees", async function (req, res) {
   response.data = await map.getPoints();
   response.zoomTargets = await map.getZoomTargets();
   console.log("/trees took time:%d ms", Date.now() - beginTime);
+  res.status(200).json(response);
+});
+
+app.get("/captures", async function (req, res) {
+  const map = new MapCapture();
+  const beginTime = Date.now();
+  await map.init(req.query);
+  const response = {};
+  response.data = await map.getPoints();
+  response.zoomTargets = await map.getZoomTargets();
+  console.log("/captures took time:%d ms", Date.now() - beginTime);
   res.status(200).json(response);
 });
 

--- a/server/models/MapCapture.js
+++ b/server/models/MapCapture.js
@@ -1,0 +1,166 @@
+const Map = require("./Map");
+const SQLCase2Capture = require("./sqls/SQLCase2Capture");
+const SQLCase1Capture = require("./sqls/SQLCase1Capture");
+const SQLCase3Capture = require("./sqls/SQLCase3Capture");
+const SQLCase4Capture = require("./sqls/SQLCase4Capture");
+const SQLZoomTargetCase1V2Capture = require("./sqls/SQLZoomTargetCase1V2Capture");
+
+class MapCapture extends Map{
+
+  async init(settings){
+    console.debug("init capture map with settings:", settings);
+    this.treeid = settings.treeid;
+    this.zoomLevel = parseInt(settings.zoom_level);
+    this.userid = settings.userid;
+    this.clusterRadius = settings.clusterRadius;
+    this.mapName = settings.map_name;
+    this.bounds = settings.bounds;
+    this.wallet = settings.wallet;
+    this.flavor = settings.flavor;
+    this.token = settings.token;
+    this.treeIds = [];
+    if(this.treeid){
+      /*
+       * Single tree map mode
+       */
+      this.sql = new SQLCase2Capture();
+      this.sql.addTreeFilter(this.treeid);
+
+    }else if(this.userid){
+      /*
+       * User map mode
+       */
+      //count the trees amount first
+      const result = await this.pool.query({
+        text: `select count(*) as count from trees where planter_id = ${this.userid}`,
+        values:[]
+      });
+      const treeCount = result.rows[0].count;
+      parseInt(treeCount);
+      if(this.zoomLevel > 15){
+        this.sql = new SQLCase2Capture();
+        this.sql.setBounds(this.bounds);
+        this.sql.addFilterByUserId(this.userid);
+      }else{
+        if(treeCount > 2000){
+          this.sql = new SQLCase1Capture();
+          this.sql.addFilterByUserId(this.userid);
+          this.sql.setZoomLevel(this.zoomLevel);
+          this.sql.setBounds(this.bounds);
+        }else{
+          this.sql = new SQLCase3Capture();
+          this.sql.setClusterRadius(this.clusterRadius);
+          this.sql.addFilterByUserid(this.userid);
+          this.sql.setBounds(this.bounds);
+        }
+      }
+      if(this.zoomLevel <= 9){
+        this.sqlZoomTarget = new SQLZoomTargetCase1V2Capture();
+        this.sqlZoomTarget.setBounds(this.bounds);
+        this.sqlZoomTarget.setZoomLevel(this.zoomLevel);
+      }
+
+    }else if(this.wallet){
+      /*
+       * wallet map mode
+       */
+      if(this.zoomLevel > 15){
+        this.sql = new SQLCase2Capture();
+        this.sql.setBounds(this.bounds);
+        this.sql.addFilterByWallet(this.wallet);
+      }else{
+        this.sql = new SQLCase3Capture();
+        this.sql.setClusterRadius(this.clusterRadius);
+        this.sql.addFilterByWallet(this.wallet);
+        this.sql.setBounds(this.bounds);
+      }
+      if(this.zoomLevel <= 9){
+        this.sqlZoomTarget = new SQLZoomTargetCase1V2Capture();
+        this.sqlZoomTarget.setBounds(this.bounds);
+        this.sqlZoomTarget.setZoomLevel(this.zoomLevel);
+      }
+
+    }else if(this.flavor){
+      /*
+       * flavor map mode
+       */
+      if(this.zoomLevel > 15){
+        this.sql = new SQLCase2Capture();
+        this.sql.setBounds(this.bounds);
+        this.sql.addFilterByFlavor(this.flavor);
+      }else{
+        this.sql = new SQLCase3Capture();
+        this.sql.setClusterRadius(this.clusterRadius);
+        this.sql.addFilterByFlavor(this.flavor);
+        this.sql.setBounds(this.bounds);
+      }
+      if(this.zoomLevel <= 9){
+        this.sqlZoomTarget = new SQLZoomTargetCase1V2Capture();
+        this.sqlZoomTarget.setBounds(this.bounds);
+        this.sqlZoomTarget.setZoomLevel(this.zoomLevel);
+      }
+
+    }else if(this.token){
+      /*
+       * Token map mode
+       */
+      if(this.zoomLevel > 15){
+        this.sql = new SQLCase2Capture();
+        this.sql.setBounds(this.bounds);
+        this.sql.addFilterByToken(this.token);
+      }else{
+        this.sql = new SQLCase3Capture();
+        this.sql.setClusterRadius(this.clusterRadius);
+        this.sql.addFilterByToken(this.token);
+        this.sql.setBounds(this.bounds);
+      }
+      if(this.zoomLevel <= 9){
+        this.sqlZoomTarget = new SQLZoomTargetCase1V2Capture();
+        this.sqlZoomTarget.setBounds(this.bounds);
+        this.sqlZoomTarget.setZoomLevel(this.zoomLevel);
+      }
+
+    }else if(this.mapName){
+      if(this.zoomLevel > 15){
+        this.sql = new SQLCase2Capture();
+        this.sql.addFilterByMapName(this.mapName);
+        this.sql.setBounds(this.bounds);
+      }else{
+        this.sql = new SQLCase1Capture();
+        this.sql.addMapNameFilter(this.mapName);
+        this.sql.setBounds(this.bounds);
+        this.sql.setZoomLevel(this.zoomLevel);
+      }
+      if(this.zoomLevel <= 9){
+        this.sqlZoomTarget = new SQLZoomTargetCase1V2Capture();
+        this.sqlZoomTarget.setBounds(this.bounds);
+        this.sqlZoomTarget.setZoomLevel(this.zoomLevel);
+        this.sqlZoomTarget.addMapNameFilter(this.mapName);
+      }
+
+    }else{
+      /*
+       * Normal map mode
+       */
+      if(this.zoomLevel > 15){
+        this.sql = new SQLCase2Capture();
+        this.sql.setBounds(this.bounds);
+      } else if ([12, 13, 14, 15].includes(this.zoomLevel)) {
+        this.sql = new SQLCase4Capture();
+        this.sql.setBounds(this.bounds)
+      }else{
+        this.sql = new SQLCase1Capture();
+        this.sql.setBounds(this.bounds)
+        this.sql.setZoomLevel(this.zoomLevel);
+      }
+      if(this.zoomLevel <= 9){
+        this.sqlZoomTarget = new SQLZoomTargetCase1V2Capture();
+        this.sqlZoomTarget.setBounds(this.bounds);
+        this.sqlZoomTarget.setZoomLevel(this.zoomLevel);
+      }
+    }
+    return;
+  }
+}
+
+module.exports = MapCapture;

--- a/server/models/sqls/SQLCase1Capture.js
+++ b/server/models/sqls/SQLCase1Capture.js
@@ -1,0 +1,6 @@
+const SQLCase1 = require("./SQLCase1");
+
+class SQLCase1Capture extends SQLCase1{
+}
+
+module.exports = SQLCase1Capture;

--- a/server/models/sqls/SQLCase2Capture.js
+++ b/server/models/sqls/SQLCase2Capture.js
@@ -1,0 +1,6 @@
+const SQLCase2 = require("./SQLCase2");
+
+class SQLCase2Capture extends SQLCase2{
+}
+
+module.exports = SQLCase2Capture;

--- a/server/models/sqls/SQLCase3Capture.js
+++ b/server/models/sqls/SQLCase3Capture.js
@@ -1,0 +1,6 @@
+const SQLCase3 = require("./SQLCase3");
+
+class SQLCase3Capture extends SQLCase3{
+}
+
+module.exports = SQLCase3Capture;

--- a/server/models/sqls/SQLCase4Capture.js
+++ b/server/models/sqls/SQLCase4Capture.js
@@ -1,0 +1,6 @@
+const SQLCase4 = require("./SQLCase4");
+
+class SQLCase4Capture extends SQLCase4{
+}
+
+module.exports = SQLCase4Capture;

--- a/server/models/sqls/SQLZoomTargetCase1V2Capture.js
+++ b/server/models/sqls/SQLZoomTargetCase1V2Capture.js
@@ -1,0 +1,6 @@
+const SQLZoomTargetCase1V2 = require("./SQLZoomTargetCase1V2");
+
+class SQLZoomTargetCase1V2Capture extends SQLZoomTargetCase1V2{
+}
+
+module.exports = SQLZoomTargetCase1V2Capture;


### PR DESCRIPTION
Resolved #216 

Features:
* Visit treetracker.org/tree for trees map.
* Visit treetracker.org for capture map (because we didn't have capture tree yet, so now it's using trees table too)
* Added API: GET /captures,  the previous API GET /trees remains the same. 

**NOTE** 
To deploy this code to test & prod env, we need to add some extra configure for Nginx:
```
    location / {
        autoindex off;
	try_files $uri /index.html;
    }
```

Add try_files to make it possible that let treetracker.org/tree to fall into the same React app. I have tested on the test server, it works. 

**Test**

Visit treetracker.org will request API /captures
<img width="1438" alt="Screen Shot 2020-11-21 at 4 36 49 PM" src="https://user-images.githubusercontent.com/5744708/99871775-1b130280-2c18-11eb-9f62-1221495ff50c.png">

Visit treetracker.org/tree will request API /trees
<img width="1438" alt="Screen Shot 2020-11-21 at 4 36 06 PM" src="https://user-images.githubusercontent.com/5744708/99871783-2a924b80-2c18-11eb-8ae7-4ab8f99173e4.png">


