### PR TITLE
Try to fix problem of Haiti map.

### DIFF
--- a/server/models/Map.js
+++ b/server/models/Map.js
@@ -126,7 +126,7 @@ class Map{
       }
 
     }else if(this.mapName){
-      if(this.zoomLevel > 15){
+      if(this.zoomLevel >= 15){
         this.sql = new SQLCase2();
         this.sql.addFilterByMapName(this.mapName);
         this.sql.setBounds(this.bounds);


### PR DESCRIPTION
A problem is that when the zoom level is 15, and the map_name is set, the previous code would use `active_tree_region` but there isn't data there for this level of data, so the map client got an empty data set for request.  
The trouble is that for the organization map, we can not use `cluster` table for zoom level: 12-15, so in this case, I have to switch to use `trees` table.